### PR TITLE
Kole - Moved leaderboard back button to right side of page

### DIFF
--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -67,6 +67,13 @@ export default function LeaderboardPage() {
         >
             <BasicLayout>
                 <div className="pt-2">
+                <Button
+                    onClick={() => navigate(-1)}
+                    data-testid="LeaderboardPage-back-button"
+                    style={{ float: "right" }}
+                >
+                    Back
+                </Button>
                     <h1>Leaderboard</h1>
                     {showLeaderboard ? (
                         <>
@@ -79,12 +86,7 @@ export default function LeaderboardPage() {
                         <p>You're not authorized to see the leaderboard.</p>
                     )}
                 </div>
-                <Button
-                    onClick={() => navigate(-1)}
-                    data-testid="LeaderboardPage-back-button"
-                >
-                    Back
-                </Button>
+
             </BasicLayout>
         </div>
     );

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -111,6 +111,7 @@ describe("LeaderboardPage tests", () => {
         );
         await screen.findByTestId("LeaderboardPage-back-button");
         const cancelButton = screen.getByTestId("LeaderboardPage-back-button");
+        expect(cancelButton).toHaveAttribute("style", "float: right;");
 
         fireEvent.click(cancelButton);
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I changed the positioning and style of the leaderboard back button to float right. It is now positioned on the right top of the leaderboard page.

## Screenshots
![image](https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/92057740/9131d32e-a4f4-41a1-948d-16ae3d542e39)

##Dokku dev deployment
https://happycows-ktkikuta-dev.dokku-04.cs.ucsb.edu/

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Visit dokku deployment
2. Test back button location and functionality.

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #9 
