### PR TITLE
HY - added pagination to OurTable component

### DIFF
--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTable, useSortBy } from 'react-table'
+import { useTable, useSortBy, usePagination } from 'react-table'
 import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
 // Stryker disable all
@@ -18,59 +18,80 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
     getTableProps,
     getTableBodyProps,
     headerGroups,
-    rows,
     prepareRow,
+    page,
+    canPreviousPage,
+    canNextPage,
+    pageCount,
+    nextPage,
+    previousPage,
+    state: { pageIndex }
   } = useTable({
     columns,
     data,
     ...(rest.initialState && {
       initialState: rest.initialState
     })
-  }, useSortBy)
+  }, useSortBy, usePagination)
 
   return (
-    <Table style={tableStyle} {...getTableProps()} striped bordered hover >
-      <thead>
-        {headerGroups.map(headerGroup => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map(column => (
-              <th
-                {...column.getHeaderProps(column.getSortByToggleProps())}
-                data-testid={`${testid}-header-${column.id}`}
-              >
-                {column.render('Header')}
-                <span data-testid={`${testid}-header-${column.id}-sort-carets`}>
-                  {column.isSorted
-                    ? column.isSortedDesc
-                      ? ' 🔽'
-                      : ' 🔼'
-                    : ''}
-                </span>
-              </th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()}>
-        {rows.map(row => {
-          prepareRow(row)
-          return (
-            <tr {...row.getRowProps()}>
-              {row.cells.map((cell, _index) => {
-                return (
-                  <td
-                    {...cell.getCellProps()}
-                    data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                  >
-                    {cell.render('Cell')}
-                  </td>
-                )
-              })}
+    <>
+      <Table style={tableStyle} {...getTableProps()} striped bordered hover >
+        <thead>
+          {headerGroups.map(headerGroup => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map(column => (
+                <th
+                  {...column.getHeaderProps(column.getSortByToggleProps())}
+                  data-testid={`${testid}-header-${column.id}`}
+                >
+                  {column.render('Header')}
+                  <span data-testid={`${testid}-header-${column.id}-sort-carets`}>
+                    {column.isSorted
+                      ? column.isSortedDesc
+                        ? ' 🔽'
+                        : ' 🔼'
+                      : ''}
+                  </span>
+                </th>
+              ))}
             </tr>
-          )
-        })}
-      </tbody>
-    </Table>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {page.map(
+            (row) =>
+              prepareRow(row) || (
+                <tr {...row.getRowProps()}>
+                  {row.cells.map((cell, _index) => {
+                    return (
+                      <td
+                        {...cell.getCellProps()}
+                        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
+                      >
+                        {cell.render('Cell')}
+                      </td>
+                    )
+                  })}
+                </tr>
+              )
+          )}
+        </tbody>
+      </Table>
+      {pageCount>1 && (
+        <div data-testid='pagination-ui'>
+          <button onClick={() => previousPage()} disabled={!canPreviousPage} data-testid='goto-previous-page-button'>
+            {'<'}
+          </button>
+          <button onClick={() => nextPage()} disabled={!canNextPage} data-testid='goto-next-page-button'>
+            {'>'}
+          </button>
+          <span data-testid={'page-indicator'}>
+            Page{' '}<strong>{pageIndex + 1} of {pageCount}</strong>
+          </span>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/frontend/src/stories/components/OurTable.stories.js
+++ b/frontend/src/stories/components/OurTable.stories.js
@@ -42,6 +42,21 @@ Sample.args = {
     ]
 };
 
-
-
+export const ThreePages = Template.bind({});
+ThreePages.args = {
+    columns: [
+        {
+            Header: 'Column 1',
+            accessor: 'col1', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Column 2',
+            accessor: 'col2',
+        },
+    ],
+    data: Array.from({ length: 26 }, (_, index) => ({
+        col1: `${index}`,
+        col2: 'whatever',
+    }))
+};
 

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -2,75 +2,36 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import OurTable, { ButtonColumn, DateColumn, PlaintextColumn} from "main/components/OurTable";
 
 describe("OurTable tests", () => {
-    const data = [
+    const threeRows = [
         {
             col1: 'Hello',
-            col2: 'asd',
+            col2: 'World',
             createdAt: '2021-04-01T04:00:00.000',
             log: "foo\nbar\n  baz",
         },
         {
             col1: 'react-table',
-            col2: 'hdhdh',
+            col2: 'rocks',
             createdAt: '2022-01-04T14:00:00.000',
             log: "foo\nbar",
 
         },
         {
             col1: 'whatever',
-            col2: 'jiji',
+            col2: 'you want',
             createdAt: '2023-04-01T23:00:00.000',
             log: "bar\n  baz",
-        },
-        {
-            col1: '3',
-            col2: '4',
-            createdAt: '2023-04-01T23:00:00.000',
-            log: "5",
-        },
-        {
-            col1: '4',
-            col2: '5',
-            createdAt: '2023-04-01T23:00:00.000',
-            log: "6",
-        },
-        {
-            col1: '5',
-            col2: '6',
-            createdAt: '2023-04-01T23:00:00.000',
-            log: "7",
-        },
-        {
-            col1: '6',
-            col2: '7',
-            createdAt: '2023-04-01T23:00:00.000',
-            log: "8",
-        },
-        {
-            col1: '7',
-            col2: '8',
-            createdAt: '2023-04-01T23:00:00.000',
-            log: "9",
-        },
-        {
-            col1: '8',
-            col2: '9',
-            createdAt: '2023-04-01T23:00:00.000',
-            log: "10",
-        },
-        {
-            col1: '9',
-            col2: '10',
-            createdAt: '2023-04-01T23:00:00.000',
-            log: "11",
-        },
-        {
-            col1: '10',
-            col2: '11',
-            createdAt: '2023-04-01T23:00:00.000',
-            log: "12",
         }
     ];
+
+    const manyRows = Array.from({ length: 11 }, (_, index) => ({
+        col1: `${index}`,
+        col2: 'whatever',
+        createdAt: '2023-04-01T23:00:00.000',
+        log: "foo\n",
+    }))
+
+    const pageSize = 10;
 
     const clickMeCallback = jest.fn();
 
@@ -94,15 +55,15 @@ describe("OurTable tests", () => {
         );
     });
 
-    test("renders a table with two rows without crashing", () => {
+    test("renders a table with three rows without crashing", () => {
         render(
-            <OurTable columns={columns} data={data.slice(0,2)} />
+            <OurTable columns={columns} data={threeRows} />
         );
     });
 
     test("The button appears in the table", async () => {
         render(
-            <OurTable columns={columns} data={data} />
+            <OurTable columns={columns} data={threeRows} />
         );
 
         expect(await screen.findByTestId("testId-cell-row-0-col-Click-button")).toBeInTheDocument();
@@ -113,14 +74,14 @@ describe("OurTable tests", () => {
 
     test("default testid is testId", async () => {
         render(
-            <OurTable columns={columns} data={data} />
+            <OurTable columns={columns} data={threeRows} />
         );
         expect(await screen.findByTestId("testid-header-col1")).toBeInTheDocument();
     });
 
     test("click on a header and a sort caret should appear", async () => {
         render(
-            <OurTable columns={columns} data={data} testid={"sampleTestId"} />
+            <OurTable columns={columns} data={threeRows} testid={"sampleTestId"} />
         );
 
         expect(await screen.findByTestId("sampleTestId-header-col1")).toBeInTheDocument();
@@ -139,34 +100,41 @@ describe("OurTable tests", () => {
         expect(await screen.findByText("🔽")).toBeInTheDocument();
     });
 
-    test("pagination ui should not be visible when the number of rows of data is less than or equal to the default page size (10)", async () => {
+    test("pagination ui should not be visible when the number of rows of data is less than or equal to the default page size", async () => {
         render(
-            <OurTable columns={columns} data={data.slice(0,10)} testid={"sampleTestId"}/>
+            <OurTable columns={columns} data={threeRows} testid={"sampleTestId"}/>
         );
-        expect(screen.getByTestId('sampleTestId-cell-row-9-col-col1')).toBeInTheDocument(); //confirm the last row is in the table of 10 rows
+        expect(screen.getByTestId(`sampleTestId-cell-row-${threeRows.length-1}-col-col1`)).toBeInTheDocument(); //confirm the last row is in the table
+        expect(screen.queryByTestId("pagination-ui")).not.toBeInTheDocument(); 
+
+        const data = manyRows.slice(0, pageSize);
+        render(
+            <OurTable columns={columns} data={data} testid={"sampleTestId"}/>
+        );
+        expect(screen.getByTestId(`sampleTestId-cell-row-${data.length-1}-col-col1`)).toBeInTheDocument(); //confirm the last row is in the table
         expect(screen.queryByTestId("pagination-ui")).not.toBeInTheDocument(); 
     });
 
-    test("pagination ui should be visible when the number of rows of data is more than the default page size (10)", async () => {
+    test("pagination ui should be visible when the number of rows of data is more than the default page size", async () => {
         render(
-            <OurTable columns={columns} data={data}/>
+            <OurTable columns={columns} data={manyRows}/>
         );
         expect(screen.getByTestId("pagination-ui")).toBeInTheDocument(); 
     });
 
     test("correct data is rendered when next page or previous page buttons is clicked", async () => {
         render(
-            <OurTable columns={columns} data={data} testid={"sampleTestId"}/>
+            <OurTable columns={columns} data={manyRows} testid={"sampleTestId"}/>
         );
         expect(await screen.findByTestId("page-indicator")).toHaveTextContent("Page 1 of 2"); // confirm current page number
-        expect(screen.getByTestId('sampleTestId-cell-row-9-col-col1')).toBeInTheDocument();
+        expect(screen.getByTestId(`sampleTestId-cell-row-${pageSize-1}-col-col1`)).toBeInTheDocument();
         fireEvent.click(screen.getByTestId("goto-next-page-button"));
         expect(await screen.findByTestId("page-indicator")).toHaveTextContent("Page 2 of 2"); 
-        expect(screen.getByTestId('sampleTestId-cell-row-10-col-col1')).toBeInTheDocument(); // confirm element in the next page is displayed
-        expect(screen.queryByTestId('sampleTestId-cell-row-9-col-col1')).not.toBeInTheDocument(); // confirm element from previousd page is not displayed
-        fireEvent.click(screen.getByTestId("goto-previous-page-button"));
+        expect(screen.getByTestId(`sampleTestId-cell-row-${pageSize}-col-col1`)).toBeInTheDocument(); // confirm element in the next page is displayed
+        expect(screen.queryByTestId(`sampleTestId-cell-row-${pageSize-1}-col-col1`)).not.toBeInTheDocument(); // confirm element from previousd page is not displayed
+        fireEvent.click(screen.getByTestId("goto-previous-page-button")); // check go to previous page button
         expect(await screen.findByTestId("page-indicator")).toHaveTextContent("Page 1 of 2"); 
-        expect(screen.queryByTestId('sampleTestId-cell-row-10-col-col1')).not.toBeInTheDocument();
-        expect(screen.getByTestId('sampleTestId-cell-row-9-col-col1')).toBeInTheDocument(); 
+        expect(screen.queryByTestId(`sampleTestId-cell-row-${pageSize}-col-col1`)).not.toBeInTheDocument();
+        expect(screen.getByTestId(`sampleTestId-cell-row-${pageSize-1}-col-col1`)).toBeInTheDocument(); 
     });
 });

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -2,27 +2,76 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import OurTable, { ButtonColumn, DateColumn, PlaintextColumn} from "main/components/OurTable";
 
 describe("OurTable tests", () => {
-    const threeRows = [
+    const data = [
         {
             col1: 'Hello',
-            col2: 'World',
+            col2: 'asd',
             createdAt: '2021-04-01T04:00:00.000',
             log: "foo\nbar\n  baz",
         },
         {
             col1: 'react-table',
-            col2: 'rocks',
+            col2: 'hdhdh',
             createdAt: '2022-01-04T14:00:00.000',
             log: "foo\nbar",
 
         },
         {
             col1: 'whatever',
-            col2: 'you want',
+            col2: 'jiji',
             createdAt: '2023-04-01T23:00:00.000',
             log: "bar\n  baz",
+        },
+        {
+            col1: '3',
+            col2: '4',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "5",
+        },
+        {
+            col1: '4',
+            col2: '5',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "6",
+        },
+        {
+            col1: '5',
+            col2: '6',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "7",
+        },
+        {
+            col1: '6',
+            col2: '7',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "8",
+        },
+        {
+            col1: '7',
+            col2: '8',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "9",
+        },
+        {
+            col1: '8',
+            col2: '9',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "10",
+        },
+        {
+            col1: '9',
+            col2: '10',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "11",
+        },
+        {
+            col1: '10',
+            col2: '11',
+            createdAt: '2023-04-01T23:00:00.000',
+            log: "12",
         }
     ];
+
     const clickMeCallback = jest.fn();
 
     const columns = [
@@ -47,13 +96,13 @@ describe("OurTable tests", () => {
 
     test("renders a table with two rows without crashing", () => {
         render(
-            <OurTable columns={columns} data={threeRows} />
+            <OurTable columns={columns} data={data.slice(0,2)} />
         );
     });
 
     test("The button appears in the table", async () => {
         render(
-            <OurTable columns={columns} data={threeRows} />
+            <OurTable columns={columns} data={data} />
         );
 
         expect(await screen.findByTestId("testId-cell-row-0-col-Click-button")).toBeInTheDocument();
@@ -64,14 +113,14 @@ describe("OurTable tests", () => {
 
     test("default testid is testId", async () => {
         render(
-            <OurTable columns={columns} data={threeRows} />
+            <OurTable columns={columns} data={data} />
         );
         expect(await screen.findByTestId("testid-header-col1")).toBeInTheDocument();
     });
 
     test("click on a header and a sort caret should appear", async () => {
         render(
-            <OurTable columns={columns} data={threeRows} testid={"sampleTestId"} />
+            <OurTable columns={columns} data={data} testid={"sampleTestId"} />
         );
 
         expect(await screen.findByTestId("sampleTestId-header-col1")).toBeInTheDocument();
@@ -88,5 +137,36 @@ describe("OurTable tests", () => {
 
         fireEvent.click(col1Header);
         expect(await screen.findByText("🔽")).toBeInTheDocument();
+    });
+
+    test("pagination ui should not be visible when the number of rows of data is less than or equal to the default page size (10)", async () => {
+        render(
+            <OurTable columns={columns} data={data.slice(0,10)} testid={"sampleTestId"}/>
+        );
+        expect(screen.getByTestId('sampleTestId-cell-row-9-col-col1')).toBeInTheDocument(); //confirm the last row is in the table of 10 rows
+        expect(screen.queryByTestId("pagination-ui")).not.toBeInTheDocument(); 
+    });
+
+    test("pagination ui should be visible when the number of rows of data is more than the default page size (10)", async () => {
+        render(
+            <OurTable columns={columns} data={data}/>
+        );
+        expect(screen.getByTestId("pagination-ui")).toBeInTheDocument(); 
+    });
+
+    test("correct data is rendered when next page or previous page buttons is clicked", async () => {
+        render(
+            <OurTable columns={columns} data={data} testid={"sampleTestId"}/>
+        );
+        expect(await screen.findByTestId("page-indicator")).toHaveTextContent("Page 1 of 2"); // confirm current page number
+        expect(screen.getByTestId('sampleTestId-cell-row-9-col-col1')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId("goto-next-page-button"));
+        expect(await screen.findByTestId("page-indicator")).toHaveTextContent("Page 2 of 2"); 
+        expect(screen.getByTestId('sampleTestId-cell-row-10-col-col1')).toBeInTheDocument(); // confirm element in the next page is displayed
+        expect(screen.queryByTestId('sampleTestId-cell-row-9-col-col1')).not.toBeInTheDocument(); // confirm element from previousd page is not displayed
+        fireEvent.click(screen.getByTestId("goto-previous-page-button"));
+        expect(await screen.findByTestId("page-indicator")).toHaveTextContent("Page 1 of 2"); 
+        expect(screen.queryByTestId('sampleTestId-cell-row-10-col-col1')).not.toBeInTheDocument();
+        expect(screen.getByTestId('sampleTestId-cell-row-9-col-col1')).toBeInTheDocument(); 
     });
 });

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -24,14 +24,15 @@ describe("OurTable tests", () => {
         }
     ];
 
-    const manyRows = Array.from({ length: 11 }, (_, index) => ({
+
+    const pageSize = 10;
+
+    const manyRows = Array.from({ length: pageSize+1 }, (_, index) => ({
         col1: `${index}`,
         col2: 'whatever',
         createdAt: '2023-04-01T23:00:00.000',
         log: "foo\n",
     }))
-
-    const pageSize = 10;
 
     const clickMeCallback = jest.fn();
 
@@ -119,7 +120,10 @@ describe("OurTable tests", () => {
         render(
             <OurTable columns={columns} data={manyRows}/>
         );
-        expect(screen.getByTestId("pagination-ui")).toBeInTheDocument(); 
+        const paginationElem = screen.getByTestId("pagination-ui");
+        expect(paginationElem).toBeInTheDocument(); 
+        expect(paginationElem).toHaveTextContent('<');
+        expect(paginationElem).toHaveTextContent('>');
     });
 
     test("correct data is rendered when next page or previous page buttons is clicked", async () => {


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I refactor OurTable component to be a pagination table with default page size of 10 rows of data. Pagination UI only shows up when there are more than 1 page of data. 

## Feedback (Optional)
- I was unable to kill all mutants after running npx stryker run -m src/tests/components/OurTable.test.js locally, but I don't know why check 33-frontend-pr-mutation-testing passed. Is it sufficient to pass the tests run by github actions? Answer: do not run mutation tests on test files.

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
- [x] storybook: https://ucsb-cs156-w24.github.io/proj-happy-cows-w24-4pm-4/prs/14/storybook/?path=/story/components-ourtable--three-pages
- [x] dokku: https://happycows-hyi96-dev.dokku-04.cs.ucsb.edu/
- [x] populate any table that uses OurTable component with more than 10 rows of data and see if pagination ui elements show up.
- [x] check go to next page and go to previous page buttons work and display the correct data and page number. 

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100%  
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #2 
