### PR TITLE
AN - fixed whitespace for leaderboard table

### DIFF
--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -5,10 +5,10 @@ import Plaintext from "main/components/Utils/Plaintext";
 // Stryker disable all
 var tableStyle = {
   "background": "white",
-  "display": "block" ,
-  "maxWidth": "-moz-fit-content" ,
-  "margin": "0 auto" ,
-  "overflowX": "auto" ,
+  "display": "table",
+  "maxWidth": "-moz-fit-content",
+  "margin": "0 auto",
+  "overflowX": "auto",
   "whiteSpace": "nowrap"
 };
 // Stryker restore all


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, the whitespace on the right of the leaderboard table is removed.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![Screenshot 2024-02-27 172210](https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/91798180/9d19a1b4-57f1-4756-9c95-5f542a59f9d8)

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #3 
