### PR TITLE
RM - CHAT-ON-OFF (4): added showChat checkbox to frontend and tests

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -377,12 +377,29 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                         >
                 <Form.Check
                     data-testid={`${testid}-showLeaderboard`}
-                    type="checkbox"
+                    type="checkbox" 
                     id="showLeaderboard"
                     {...register("showLeaderboard")}
                 />
                 </OverlayTrigger>
             </Form.Group>
+
+            <Form.Group className="mb-3">
+                <Form.Label htmlFor="showChat">Show Chat?</Form.Label>
+                <OverlayTrigger
+                            placement="bottom"
+                            overlay={<Tooltip>When checked, regular users will have access to the chat for this commons. When unchecked, only admins can see the chat for this commons.</Tooltip>}
+                            delay = '100'
+                        >
+                <Form.Check
+                    data-testid={`${testid}-showChat`}
+                    type="checkbox"
+                    id="showChat"
+                    {...register("showChat")}
+                />
+                </OverlayTrigger>
+            </Form.Group>
+
             <Row className="mb-5">
                 <Button type="submit"
                         data-testid="CommonsForm-Submit-Button"

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -38,7 +38,6 @@ export default function CommonsTable({ commons, currentUser }) {
         const route = `/leaderboard/${cell.row.values["commons.id"]}`
         navigate(route)
     }
-
     const columns = [
         {
             Header: 'id',
@@ -83,6 +82,11 @@ export default function CommonsTable({ commons, currentUser }) {
             Header:<span> Show <br /> LrdrBrd? </span>,
             id: 'commons.showLeaderboard', // needed for tests
             accessor: (row, _rowIndex) => String(row.commons.showLeaderboard) // hack needed for boolean values to show up
+        },
+        {
+            Header:<span> Show <br /> Chat? </span>,
+            id: 'commons.showChat', // needed for tests
+            accessor: (row, _rowIndex) => String(row.commons.showChat) // hack needed for boolean values to show up
         },
         {
             Header: <span> Tot <br /> Cows </span>,

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -84,11 +84,6 @@ export default function CommonsTable({ commons, currentUser }) {
             accessor: (row, _rowIndex) => String(row.commons.showLeaderboard) // hack needed for boolean values to show up
         },
         {
-            Header:<span> Show <br /> Chat? </span>,
-            id: 'commons.showChat', // needed for tests
-            accessor: (row, _rowIndex) => String(row.commons.showChat) // hack needed for boolean values to show up
-        },
-        {
             Header: <span> Tot <br /> Cows </span>,
             accessor: 'totalCows'
         },

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -51,6 +51,7 @@ describe("CommonsForm tests", () => {
       /Capacity Per User/,
       /Carrying Capacity/,
       /Show Leaderboard\?/,
+      /Show Chat\?/,
       /When below capacity/,
       /When above capacity/,
 
@@ -138,6 +139,14 @@ describe("CommonsForm tests", () => {
 
     [
       "CommonsForm-showLeaderboard",
+    ].forEach(
+      (testid) => {
+        const element = screen.getByTestId(testid);
+        expect(element).toBeInTheDocument();
+      }
+    );
+    [
+      "CommonsForm-showChat",
     ].forEach(
       (testid) => {
         const element = screen.getByTestId(testid);

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -70,6 +70,7 @@ describe("AdminCreateCommonsPage tests", () => {
             "aboveCapacityHealthUpdateStrategy": "strat2",
             "belowCapacityHealthUpdateStrategy": "strat3",
             "showLeaderboard": false,
+            "showChat": false
         });
 
         render(
@@ -94,6 +95,7 @@ describe("AdminCreateCommonsPage tests", () => {
         const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText("When above capacity");
         const belowCapacityHealthUpdateStrategyField = screen.getByLabelText("When below capacity");
         const showLeaderboardField = screen.getByLabelText("Show Leaderboard?");
+        const showChatField = screen.getByLabelText("Show Chat?");
         const button = screen.getByTestId("CommonsForm-Submit-Button");
 
         fireEvent.change(commonsNameField, { target: { value: 'My New Commons' } })
@@ -106,6 +108,7 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(capacityPerUserField, { target: { value: '10' } })
         fireEvent.change(carryingCapacityField, { target: { value: '25' } })
         fireEvent.change(showLeaderboardField, { target: { value: true } })
+        fireEvent.change(showChatField, {target: { value: true} })
 
         fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: {value: 'strat2' } })
         fireEvent.change(belowCapacityHealthUpdateStrategyField, { target: {value: 'strat3' } })
@@ -128,6 +131,7 @@ describe("AdminCreateCommonsPage tests", () => {
             startingDate: '2022-03-05T00:00:00.000Z',
             lastDate: '2023-03-05T00:00:00.000Z',
             showLeaderboard: false,
+            showChat: false,
             aboveCapacityHealthUpdateStrategy: "strat2",
             belowCapacityHealthUpdateStrategy: "strat3",
         };


### PR DESCRIPTION
## Overview
Added showChat checkbox to frontend. Appears on storybook and on localhost. showChat field updates accordingly in database on swagger. Branch: EPIC-CHAT-COMMONS-FORM

## Screenshots (Optional)
<img width="467" alt="image" src="https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/91815408/bfc74219-68bd-4612-b5cf-137d85518434">

<img width="960" alt="image" src="https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/91815408/76c861e0-8558-4241-93c9-38d693d8d564">

<img width="923" alt="image" src="https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/91815408/401c6d17-11a1-4164-b60a-0d192a65e4de">



### Testing 
- [x] npm test
- [x] npm run coverage
- [x]  npx stryker run -m src/main/components/Commons/CommonsForm.js
- [x]  npx stryker run -m src/main/pages/AdminCreateCommonsPage.js
- [x] npx eslint --fix src

## Linked Issues
Closes #28 
