### PR TITLE
AN - B2 added controllers and tests for Announcements

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -52,19 +52,6 @@ public class AnnouncementsController extends ApiController {
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping("/get")
     public ResponseEntity<String> getAnnouncements(@Parameter(description = "The id of the common") @RequestParam Long commonsId) throws JsonProcessingException {
-        
-        // Make sure the user is part of the commons or is an admin
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (!auth.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))){
-            log.info("User is not an admin");
-            User user = getCurrentUser().getUser();
-            Long userId = user.getId();
-            Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
-
-            if (!userCommonsLookup.isPresent()) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-            }
-        }
 
         // Return the list of announcements
         Iterable<Announcements> messages = announcementsRepository.findAllByCommonsId(commonsId);
@@ -76,7 +63,7 @@ public class AnnouncementsController extends ApiController {
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping("/get/by-id")
     public ResponseEntity<String> getAnnouncementsById(@Parameter(description = "The id of the announcement") @RequestParam Long announcementId) throws JsonProcessingException {
-        
+
         // Try to get the announcement
         Optional<Announcements> announcementLookup = announcementsRepository.findById(announcementId);
         if (!announcementLookup.isPresent()) {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -1,0 +1,235 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import edu.ucsb.cs156.happiercows.entities.Announcements;
+import edu.ucsb.cs156.happiercows.repositories.AnnouncementsRepository;
+
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+
+import org.springframework.security.core.Authentication;
+
+import java.util.Optional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.time.LocalDateTime;
+
+@Tag(name = "Announcements")
+@RequestMapping("/api/announcements")
+@RestController
+@Slf4j
+public class AnnouncementsController extends ApiController {
+    @Autowired
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    AnnouncementsRepository announcementsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Operation(summary = "Get all announcements", description = "Get all announcements associated with a specific commons.")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @GetMapping("/get")
+    public ResponseEntity<String> getAnnouncements(@Parameter(description = "The id of the common") @RequestParam Long commonsId) throws JsonProcessingException {
+        
+        // Make sure the user is part of the commons or is an admin
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (!auth.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))){
+            log.info("User is not an admin");
+            User user = getCurrentUser().getUser();
+            Long userId = user.getId();
+            Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
+
+            if (!userCommonsLookup.isPresent()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+        }
+
+        // Return the list of announcements
+        Iterable<Announcements> messages = announcementsRepository.findAllByCommonsId(commonsId);
+        String body = mapper.writeValueAsString(messages);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary = "Get announcement by id", description = "Get announcement associated with a specific id.")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @GetMapping("/get/by-id")
+    public ResponseEntity<String> getAnnouncementsById(@Parameter(description = "The id of the announcement") @RequestParam Long announcementId) throws JsonProcessingException {
+        
+        // Try to get the announcement
+        Optional<Announcements> announcementLookup = announcementsRepository.findById(announcementId);
+        if (!announcementLookup.isPresent()) {
+            String responseString = String.format("Announcement with id %d not found", announcementId);
+            return ResponseEntity.badRequest().body(responseString);
+        }
+
+        // Return the announcement
+        String body = mapper.writeValueAsString(announcementLookup);
+        return ResponseEntity.ok().body(body);
+    }  
+    
+    @Operation(summary = "Create an announcement", description = "Create an announcement associated with a specific commons")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @PostMapping("/post")
+    public ResponseEntity<String> createAnnouncements(@Parameter(description = "The id of the common") @RequestParam Long commonsId,
+                                            @Parameter(name="start", description="Start time (in iso format, e.g. YYYY-mm-ddTHH:MM:SS) ex: 2024-03-06T04:26:58.76") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+                                            @Parameter(name="end", description="End time (in iso format)") @RequestParam(name = "end", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+                                            @Parameter(name="announcement") @RequestParam String announcement) {
+        
+        User user = getCurrentUser().getUser();
+        Long userId = user.getId();
+
+        // Make sure the commons exists
+        if (!commonsRepository.findById(commonsId).isPresent()) {
+            String responseString = String.format("Commons with id %d not found", commonsId);
+            return ResponseEntity.badRequest().body(responseString);
+        }
+
+        // Make sure the user is part of the commons or is an admin
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (!auth.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))){
+            log.info("User is not an admin");
+            Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
+
+            if (!userCommonsLookup.isPresent()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+        }
+
+        // Ensure start date is before end date
+        if (end != null) {
+            if (end.isBefore(start)) {
+                return ResponseEntity.badRequest().body("End time must be after start time");
+            }
+        }
+
+        // Check if announcements is empty
+        if (announcement.isEmpty()) {
+            return ResponseEntity.badRequest().body("Announcement cannot be empty");
+        }
+
+        // Create the announcement
+        Announcements announcements = Announcements.builder()
+        .commonsId(commonsId)
+        .start(start)
+        .end(end)
+        .announcement(announcement)
+        .build();
+
+        // Save the announcement
+        announcementsRepository.save(announcements);
+        String responseString = String.format("Added announcement to commons with id %d", commonsId);
+
+        return ResponseEntity.ok().body(responseString);
+    }
+
+    @Operation(summary = "Delete an announcement", description = "Delete an announcement associated with a specific commons")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteAnnouncements(
+        @Parameter(description = "The id of the announcement") @RequestParam Long announcementId) {
+
+        // Try to get the announcement
+        Optional<Announcements> announcementLookup = announcementsRepository.findById(announcementId);
+        if (!announcementLookup.isPresent()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        Announcements announcement = announcementLookup.get();
+
+        User user = getCurrentUser().getUser();
+        Long userId = user.getId();
+
+        // Check if the user is an admin
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (!auth.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))){
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        // Delete the announcement
+        announcementsRepository.delete(announcement);
+        String responseString = String.format("announcement with id %d deleted", announcementId);
+        return genericMessage(responseString);
+    }
+
+    @Operation(summary = "Update an announcement", description = "Update an announcement associated with a specific id")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @PutMapping("")
+    public ResponseEntity<String> updateAnnouncements(@Parameter(description = "The id of the announcement") @RequestParam Long announcementId,
+                                            @Parameter(description = "The id of the common") @RequestParam Long commonsId,
+                                            @Parameter(name="start", description="Start time (in iso format, e.g. YYYY-mm-ddTHH:MM:SS) ex: 2024-03-06T04:26:58.76") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+                                            @Parameter(name="end", description="End time (in iso format)") @RequestParam(name = "end", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+                                            @Parameter(name="announcement") @RequestParam String announcement) {
+        
+        User user = getCurrentUser().getUser();
+        Long userId = user.getId();
+
+        // Try to get the announcement
+        Optional<Announcements> exists = announcementsRepository.findById(announcementId);
+        if (!exists.isPresent()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        Announcements announcements = exists.get();
+
+        // Make sure the commons exists
+        if (!commonsRepository.findById(commonsId).isPresent()) {
+            String responseString = String.format("Commons with id %d not found", commonsId);
+            return ResponseEntity.badRequest().body(responseString);
+        }
+
+        // Make sure the user is part of the commons or is an admin
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (!auth.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))){
+            log.info("User is not an admin");
+            Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
+
+            if (!userCommonsLookup.isPresent()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+        }
+
+        // Ensure start date is before end date
+        if (end != null) {
+            if (end.isBefore(start)) {
+                return ResponseEntity.badRequest().body("End time must be after start time");
+            }
+        }
+
+        // Check if announcements is empty
+        if (announcement.isEmpty()) {
+            return ResponseEntity.badRequest().body("Announcement cannot be empty");
+        }
+
+        // Update the announcement
+        announcements.setCommonsId(commonsId);
+        announcements.setStart(start);
+        announcements.setEnd(end);
+        announcements.setAnnouncement(announcement);
+
+        // Save the announcement
+        announcementsRepository.save(announcements);
+        String responseString = String.format("Updated announcement with id %d", announcementId);
+        return ResponseEntity.ok().body(responseString);
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/AnnouncementsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/AnnouncementsRepository.java
@@ -2,10 +2,9 @@ package edu.ucsb.cs156.happiercows.repositories;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
-
 import edu.ucsb.cs156.happiercows.entities.Announcements;
 
 @Repository
 public interface AnnouncementsRepository extends CrudRepository<Announcements, Long> {
-    
+    Iterable<Announcements> findAllByCommonsId(Long commonsId);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -689,9 +689,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long userId = 1L;
         String announcement = "test";
         LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
-        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
 
-        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).announcement(announcement).build();
 
         when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
         UserCommons userCommons = UserCommons.builder().build();
@@ -702,8 +701,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         LocalDateTime end2 = LocalDateTime.parse("2022-03-08T15:50:10");
 
         // act 
-        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", 
-        id, commonsId, start2, end2, announcement2).with(csrf()))
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&announcement={announcement}", 
+        id, commonsId, start2, announcement2).with(csrf()))
             .andExpect(status().isOk()).andReturn();
 
         verify(announcementsRepository, atLeastOnce()).save(any(Announcements.class));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -1,0 +1,734 @@
+package edu.ucsb.cs156.happiercows.controllers;
+import com.fasterxml.jackson.core.type.TypeReference;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.repositories.AnnouncementsRepository;
+import edu.ucsb.cs156.happiercows.entities.Announcements;
+
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
+import edu.ucsb.cs156.happiercows.services.CommonsPlusBuilderService;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebMvcTest(controllers = AnnouncementsController.class)
+@Import(AnnouncementsController.class)
+@AutoConfigureDataJpa
+public class AnnouncementsControllerTests extends ControllerTestCase {
+
+    @MockBean
+    AnnouncementsRepository announcementsRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+
+    //* */ post tests
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void createAnnouncementsTest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.save(any(Announcements.class))).thenReturn(announcements);
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(announcementsRepository, atLeastOnce()).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("Added announcement to commons with id %d", commonsId);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userNotInCommonsCannotPost() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.save(any(Announcements.class))).thenReturn(announcements);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void cannotPostWithoutStart() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).announcement(announcement).build();
+
+        when(announcementsRepository.save(any(Announcements.class))).thenReturn(announcements);
+
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&announcement={announcement}&start=", commonsId, announcement).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void endCannotBeBeforeStart() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-04T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.save(any(Announcements.class))).thenReturn(announcements);
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("End time must be after start time");
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void announcementCannotBeEmpty() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-06T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.save(any(Announcements.class))).thenReturn(announcements);
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("Announcement cannot be empty");
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userCommonsCanPost() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).announcement(announcement).build();
+
+        when(announcementsRepository.save(any(Announcements.class))).thenReturn(announcements);
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&announcement={announcement}", commonsId, start, announcement).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(announcementsRepository, atLeastOnce()).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("Added announcement to commons with id %d", commonsId);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void cannotPostIfCommonsInvalid() throws Exception {
+        Long commonsId = 1L;
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-06T15:50:10");
+
+        when(commonsRepository.findById(commonsId)).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("Commons with id %d not found", commonsId);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    // Get tests
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void getAllAnnouncementsTest() throws Exception {
+        List<Announcements> expectedAnnouncements = new ArrayList<Announcements>();
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements1 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+        Announcements announcements2 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+        expectedAnnouncements.add(announcements1);
+        expectedAnnouncements.add(announcements2);
+
+        when(announcementsRepository.findAllByCommonsId(commonsId)).thenReturn(expectedAnnouncements);
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(get("/api/announcements/get?commonsId={commonsId}", commonsId).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+        
+
+        // assert
+        
+        String announcementString = response.getResponse().getContentAsString();
+        List<Announcements> actualAnnouncements = mapper.readValue(announcementString, new TypeReference<List<Announcements>>() {
+        });
+        assertEquals(actualAnnouncements, expectedAnnouncements);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userInCommonsCanGetAll() throws Exception {
+        List<Announcements> expectedAnnouncements = new ArrayList<Announcements>();
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements1 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+        Announcements announcements2 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+        expectedAnnouncements.add(announcements1);
+        expectedAnnouncements.add(announcements2);
+
+        when(announcementsRepository.findAllByCommonsId(commonsId)).thenReturn(expectedAnnouncements);
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
+
+        //act 
+        MvcResult response = mockMvc.perform(get("/api/announcements/get?commonsId={commonsId}", commonsId).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+        
+
+        // assert
+        
+        String announcementString = response.getResponse().getContentAsString();
+        List<Announcements> actualAnnouncements = mapper.readValue(announcementString, new TypeReference<List<Announcements>>() {
+        });
+        assertEquals(actualAnnouncements, expectedAnnouncements);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userNotInCommonsCannotGetAll() throws Exception {
+        List<Announcements> expectedAnnouncements = new ArrayList<Announcements>();
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements1 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+        Announcements announcements2 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+        expectedAnnouncements.add(announcements1);
+        expectedAnnouncements.add(announcements2);
+
+        when(announcementsRepository.findAllByCommonsId(commonsId)).thenReturn(expectedAnnouncements);
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(get("/api/announcements/get?commonsId={commonsId}", commonsId).with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void getByIdTest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements1 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.findById(commonsId)).thenReturn(Optional.of(announcements1));
+
+        //act 
+        MvcResult response = mockMvc.perform(get("/api/announcements/get/by-id?announcementId={announcementId}", id).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+        
+
+        // assert
+        
+        String announcementString = response.getResponse().getContentAsString();
+        String expectedAnnouncements = mapper.writeValueAsString(announcements1);
+        assertEquals(announcementString, expectedAnnouncements);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void cannotGetNonexistentAnnouncementById() throws Exception {
+        Long id = 0L;
+        when(announcementsRepository.findById(id)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(get("/api/announcements/get/by-id?announcementId={announcementId}", id).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+    }
+
+    // Delete Tests
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void deleteAnnouncementsTest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+
+        // act 
+        MvcResult response = mockMvc.perform(delete("/api/announcements?announcementId={announcementId}", id).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        verify(announcementsRepository, atLeastOnce()).delete(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("{\"message\":\"announcement with id 0 deleted\"}", id);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userCannotDelete() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+
+        // act 
+        MvcResult response = mockMvc.perform(delete("/api/announcements?announcementId={announcementId}", id).with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
+
+        verify(announcementsRepository, times(0)).delete(any(Announcements.class));
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void cannotDeleteNonexistentAnnouncement() throws Exception {
+    
+        Long id = 0L;
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.empty());
+
+        // act 
+        MvcResult response = mockMvc.perform(delete("/api/announcements?announcementId={announcementId}", id).with(csrf()))
+            .andExpect(status().isNotFound()).andReturn();
+
+        verify(announcementsRepository, times(0)).delete(any(Announcements.class));
+    }
+
+    // Put Tests
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void updateAnnouncementsTest() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+
+        Long commonsId2 = 10L;
+        String announcement2 = "test2";
+        LocalDateTime start2 = LocalDateTime.parse("2022-03-07T15:50:10");
+        LocalDateTime end2 = LocalDateTime.parse("2022-03-08T15:50:10");
+        when(commonsRepository.findById(10L)).thenReturn(Optional.of(commons));
+
+        // act 
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", 
+        id, commonsId2, start2, end2, announcement2).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        verify(announcementsRepository, atLeastOnce()).save(any(Announcements.class));
+        assertEquals(announcements.getCommonsId(), commonsId2);
+        assertEquals(announcements.getStart(), start2);
+        assertEquals(announcements.getEnd(), end2);
+        assertEquals(announcements.getAnnouncement(), announcement2);
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("Updated announcement with id %d", id);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userNotInCommonsCannotUpdate() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", id, commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void cannotUpdateWithoutStart() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).announcement(announcement).build();
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&announcement={announcement}&start=", id, commonsId, announcement).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void endCannotBeBeforeStartUpdate() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-04T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", id, commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("End time must be after start time");
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void announcementCannotBeEmptyUpdate() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-06T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", id, commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("Announcement cannot be empty");
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void cannotUpdateIfCommonsInvalid() throws Exception {
+        Long commonsId = 1L;
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-06T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(commonsRepository.findById(commonsId)).thenReturn(Optional.empty());
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", id, commonsId, start, end, announcement).with(csrf()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(announcementsRepository, times(0)).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("Commons with id %d not found", commonsId);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userCommonsCanUpdate() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons commons = Commons.builder().build();
+        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
+        
+        Long commonsId = commons.getId();
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Announcements announcements = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.of(announcements));
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
+
+        String announcement2 = "test2";
+        LocalDateTime start2 = LocalDateTime.parse("2022-03-07T15:50:10");
+        LocalDateTime end2 = LocalDateTime.parse("2022-03-08T15:50:10");
+
+        // act 
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", 
+        id, commonsId, start2, end2, announcement2).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        verify(announcementsRepository, atLeastOnce()).save(any(Announcements.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = String.format("Updated announcement with id %d", id);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void cannotUpdateNonexistentAnnouncement() throws Exception {
+    
+        Long commonsId = 1L;
+        Long id = 0L;
+        Long userId = 1L;
+        String announcement = "test";
+        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        when(announcementsRepository.findById(id)).thenReturn(Optional.empty());
+
+        // act 
+        MvcResult response = mockMvc.perform(put("/api/announcements?announcementId={announcementId}&commonsId={commonsId}&start={start}&announcement={announcement}", id, commonsId, start, announcement).with(csrf()))
+            .andExpect(status().isNotFound()).andReturn();
+
+        verify(announcementsRepository, times(0)).delete(any(Announcements.class));
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -347,37 +347,6 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         assertEquals(actualAnnouncements, expectedAnnouncements);
     }
 
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void userNotInCommonsCannotGetAll() throws Exception {
-        List<Announcements> expectedAnnouncements = new ArrayList<Announcements>();
-        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
-
-        Commons commons = Commons.builder().build();
-        when(commonsRepository.findById(commons.getId())).thenReturn(Optional.of(commons));
-        
-        Long commonsId = commons.getId();
-        Long id = 0L;
-        Long userId = 1L;
-        String announcement = "test";
-        LocalDateTime start = LocalDateTime.parse("2022-03-05T15:50:10");
-        LocalDateTime end = LocalDateTime.parse("2022-03-05T15:50:10");
-
-        Announcements announcements1 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
-        Announcements announcements2 = Announcements.builder().id(id).commonsId(commonsId).start(start).end(end).announcement(announcement).build();
-        expectedAnnouncements.add(announcements1);
-        expectedAnnouncements.add(announcements2);
-
-        when(announcementsRepository.findAllByCommonsId(commonsId)).thenReturn(expectedAnnouncements);
-
-        UserCommons userCommons = UserCommons.builder().build();
-        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
-
-        //act 
-        MvcResult response = mockMvc.perform(get("/api/announcements/get?commonsId={commonsId}", commonsId).with(csrf()))
-            .andExpect(status().isForbidden()).andReturn();
-    }
-
     @WithMockUser(roles = {"ADMIN"})
     @Test
     public void getByIdTest() throws Exception {


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I created controller for Annoucements and added tests.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![Screenshot 2024-03-06 144542](https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/91798180/3fb4c596-d5c7-44df-b8e4-697caa41806a)

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. npm start
3. mvn spring-boot:run
4.  Log in, go to swagger
5.  Test endpoints and validations

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #20 
