### PR TITLE
HL - CHAT-ON-OFF (5): show/hide chat button

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -121,13 +121,6 @@ export default function PlayPage() {
         mutationsell.mutate(userCommons, numCows);
     };
 
-    /*const isAdmin = currentUser?.roles?.includes('ROLE_ADMIN');
-    const canShowChat = isAdmin || commonsPlus?.showChat;
-
-    console.log("Is Admin:", isAdmin);
-    console.log("Show Chat (from commonsPlus):", commonsPlus?.showChat);
-    console.log("Can Show Chat:", canShowChat);*/
-
     const [isChatOpen, setIsChatOpen] = useState(false);
 
     const toggleChatWindow = () => {

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -10,6 +10,7 @@ import ManageCows from "main/components/Commons/ManageCows";
 import Profits from "main/components/Commons/Profits";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
+import { hasRole } from "main/utils/currentUser";
 import Background from "../../assets/PlayPageBackground.jpg";
 import ChatPanel from "main/components/Chat/ChatPanel";
 import ManageCowsModal from "main/components/Commons/ManageCowsModal";
@@ -120,6 +121,13 @@ export default function PlayPage() {
         mutationsell.mutate(userCommons, numCows);
     };
 
+    /*const isAdmin = currentUser?.roles?.includes('ROLE_ADMIN');
+    const canShowChat = isAdmin || commonsPlus?.showChat;
+
+    console.log("Is Admin:", isAdmin);
+    console.log("Show Chat (from commonsPlus):", commonsPlus?.showChat);
+    console.log("Can Show Chat:", canShowChat);*/
+
     const [isChatOpen, setIsChatOpen] = useState(false);
 
     const toggleChatWindow = () => {
@@ -193,25 +201,28 @@ export default function PlayPage() {
                         </CardGroup>
                     )}
                 </Container>
+
             </BasicLayout>
-            <div style={chatContainerStyle} data-testid="playpage-chat-div">
-                {!!isChatOpen && <ChatPanel commonsId={commonsId} />}
-                <Button
-                    style={chatButtonStyle}
-                    onClick={toggleChatWindow}
-                    data-testid="playpage-chat-toggle"
-                >
-                    {!!isChatOpen ? (
-                        <span style={emojiStyle} data-testid="close-icon">
-                            ❌
-                        </span>
-                    ) : (
-                        <span style={emojiStyle} data-testid="message-icon">
-                            💬
-                        </span>
-                    )}
-                </Button>
-            </div>
+            { (hasRole(currentUser, "ROLE_ADMIN") || (!!commonsPlus && commonsPlus.commons.showChat)) &&
+                <div style={chatContainerStyle} data-testid="playpage-chat-div">
+                    {!!isChatOpen && <ChatPanel commonsId={commonsId} />}
+                    <Button
+                        style={chatButtonStyle}
+                        onClick={toggleChatWindow}
+                        data-testid="playpage-chat-toggle"
+                    >
+                        {!!isChatOpen ? (
+                            <span style={emojiStyle} data-testid="close-icon">
+                                ❌
+                            </span>
+                        ) : (
+                            <span style={emojiStyle} data-testid="message-icon">
+                                💬
+                            </span>
+                        )}
+                    </Button>
+                </div>
+            }
         </div>
     );
 }

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -34,7 +34,8 @@ describe("PlayPage tests", () => {
             commonsId: 1,
             id: 1,
             totalWealth: 0,
-            userId: 1
+            userId: 1,
+            showChat: true
         };
         axiosMock.reset();
         axiosMock.resetHistory();
@@ -54,7 +55,9 @@ describe("PlayPage tests", () => {
         axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
             commons: {
                 id: 1,
-                name: "Sample Commons"
+                name: "Sample Commons",
+                showChat: true
+
             },
             totalPlayers: 5,
             totalCows: 5
@@ -245,4 +248,100 @@ describe("PlayPage tests", () => {
 
         expect(() => screen.getByTestId("buy-sell-cow-modal")).toThrow();
     });
+
+    test("Don't show chat button for role user if showChat is false", async () => {
+        const userCommons = {
+            commonsId: 1,
+            id: 1,
+            totalWealth: 0,
+            userId: 1,
+        };
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/usercommons/forcurrentuser", { params: { commonsId: 1 } }).reply(200, userCommons);
+        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
+            id: 1,
+            name: "Sample Commons"
+        });
+        axiosMock.onGet("/api/commons/all").reply(200, [
+            {
+                id: 1,
+                name: "Sample Commons"
+            }
+        ]);
+        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
+            commons: {
+                id: 1,
+                name: "Sample Commons",
+                showChat: false,
+            },
+            totalPlayers: 2,
+            totalCows: 2 
+        });
+        axiosMock.onGet("/api/profits/all/commonsid").reply(200, []);
+        axiosMock.onPut("/api/usercommons/sell").reply(200, userCommons);
+        axiosMock.onPut("/api/usercommons/buy").reply(200, userCommons);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("playpage-chat-toggle")).not.toBeInTheDocument();
+        });
+    })
+
+    test("Shows chat button for admins if showChat is false", async () => {
+        const userCommons = {
+            commonsId: 1,
+            id: 1,
+            totalWealth: 0,
+            userId: 1,
+        };
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/usercommons/forcurrentuser", { params: { commonsId: 1 } }).reply(200, userCommons);
+        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
+            id: 1,
+            name: "Sample Commons"
+        });
+        axiosMock.onGet("/api/commons/all").reply(200, [
+            {
+                id: 1,
+                name: "Sample Commons"
+            }
+        ]);
+        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
+            commons: {
+                id: 1,
+                name: "Sample Commons",
+                showChat: false,
+            },
+            totalPlayers: 2,
+            totalCows: 2
+        });
+        axiosMock.onGet("/api/profits/all/commonsid").reply(200, []);
+        axiosMock.onPut("/api/usercommons/sell").reply(200, userCommons);
+        axiosMock.onPut("/api/usercommons/buy").reply(200, userCommons);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("playpage-chat-toggle")).toBeInTheDocument();
+        });
+    })
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I make it so that in a commons the chat button will either be hide or display to the users based on the showChat value. This doesn't affect admins. If a user is not admin and showChat is false then the user will not see a chat button at the bottom right of the screen.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![image](https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/97082279/395e521b-8079-4e14-a8e6-889005d1075b)
![image](https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/97082279/5b1b0cbb-130e-4723-a57e-49d6fae513c2)
![image](https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/97082279/53a4e9d3-c106-4e50-aad6-91f660dd37eb)
![image](https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-4/assets/97082279/9c1ca84b-700b-402c-81c9-ae817e4775b3)



## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #32 
